### PR TITLE
new: Use -baseline Binary if avx2 not supported on Linux.

### DIFF
--- a/src/proto.rs
+++ b/src/proto.rs
@@ -56,9 +56,18 @@ pub fn download_prebuilt(
         _ => unreachable!(),
     };
 
+    let mut avx2_suffix = "";
+
+    if env.arch == HostArch::X64 && env.os == HostOS::Linux && command_exists(&env, "grep") {
+        let output = exec_command!("grep", ["avx2", "/proc/cpuinfo"]);
+        if output.exit_code != 0 {
+            avx2_suffix = "-baseline";
+        }
+    };
+
     let prefix = match env.os {
-        HostOS::Linux => format!("bun-linux-{arch}"),
-        HostOS::MacOS => format!("bun-darwin-{arch}"),
+        HostOS::Linux => format!("bun-linux-{arch}{avx2_suffix}"),
+        HostOS::MacOS => format!("bun-darwin-{arch}{avx2_suffix}"),
         _ => unreachable!(),
     };
 


### PR DESCRIPTION
This checks if the avx2 instruction set is supported on x64 Linux and downloads the -baseline binary if not. Normally Zig throws an error on older devices (I'm writing this on a 2011 Sony). This should also be implemented for MacOS (I tried implementing this but failed and I have no Mac so I can't test/debug) and in the future Windows.

A better implementation should probably use the inbuilt std::is_x86_feature_detected macro but it's not available on WASM builds.

Thanks, Frederik Zorn